### PR TITLE
Release 0.1.0

### DIFF
--- a/pinterest/generated/client/model/ad_create_request.py
+++ b/pinterest/generated/client/model/ad_create_request.py
@@ -381,7 +381,7 @@ class AdCreateRequest(ModelComposed):
           'anyOf': [
           ],
           'allOf': [
-              AdCommon,
+
           ],
           'oneOf': [
           ],

--- a/pinterest/generated/client/model/ad_group_create_request.py
+++ b/pinterest/generated/client/model/ad_group_create_request.py
@@ -391,8 +391,7 @@ class AdGroupCreateRequest(ModelComposed):
           'anyOf': [
           ],
           'allOf': [
-              AdGroupCommon,
-              AdGroupCreateRequestAllOf,
+
           ],
           'oneOf': [
           ],

--- a/pinterest/generated/client/model/ad_group_response.py
+++ b/pinterest/generated/client/model/ad_group_response.py
@@ -443,8 +443,7 @@ class AdGroupResponse(ModelComposed):
           'anyOf': [
           ],
           'allOf': [
-              AdGroupCommon,
-              AdGroupResponseAllOf,
+
           ],
           'oneOf': [
           ],

--- a/pinterest/generated/client/model/ad_group_update_request.py
+++ b/pinterest/generated/client/model/ad_group_update_request.py
@@ -398,8 +398,7 @@ class AdGroupUpdateRequest(ModelComposed):
           'anyOf': [
           ],
           'allOf': [
-              AdGroupCommon,
-              AdGroupUpdateRequestAllOf,
+
           ],
           'oneOf': [
           ],

--- a/pinterest/generated/client/model/ad_preview_request.py
+++ b/pinterest/generated/client/model/ad_preview_request.py
@@ -315,6 +315,7 @@ class AdPreviewRequest(ModelComposed):
           'anyOf': [
           ],
           'allOf': [
+
           ],
           'oneOf': [
               AdPreviewCreateFromImage,

--- a/pinterest/generated/client/model/ad_response.py
+++ b/pinterest/generated/client/model/ad_response.py
@@ -500,8 +500,7 @@ class AdResponse(ModelComposed):
           'anyOf': [
           ],
           'allOf': [
-              AdCommon,
-              AdResponseAllOf,
+
           ],
           'oneOf': [
           ],

--- a/pinterest/generated/client/model/ad_update_request.py
+++ b/pinterest/generated/client/model/ad_update_request.py
@@ -392,8 +392,7 @@ class AdUpdateRequest(ModelComposed):
           'anyOf': [
           ],
           'allOf': [
-              AdCommon,
-              AdUpdateRequest1,
+
           ],
           'oneOf': [
           ],

--- a/pinterest/generated/client/model/ads_analytics_create_async_request.py
+++ b/pinterest/generated/client/model/ads_analytics_create_async_request.py
@@ -480,8 +480,7 @@ class AdsAnalyticsCreateAsyncRequest(ModelComposed):
           'anyOf': [
           ],
           'allOf': [
-              AdsAnalyticsCreateAsyncRequestAllOf,
-              AdsAnalyticsCreateAsyncRequestAllOf1,
+
           ],
           'oneOf': [
           ],

--- a/pinterest/generated/client/model/audience_create_request.py
+++ b/pinterest/generated/client/model/audience_create_request.py
@@ -332,8 +332,7 @@ class AudienceCreateRequest(ModelComposed):
           'anyOf': [
           ],
           'allOf': [
-              AudienceCommon,
-              AudienceCreateRequest1,
+
           ],
           'oneOf': [
           ],

--- a/pinterest/generated/client/model/audience_update_request.py
+++ b/pinterest/generated/client/model/audience_update_request.py
@@ -332,8 +332,7 @@ class AudienceUpdateRequest(ModelComposed):
           'anyOf': [
           ],
           'allOf': [
-              AudienceCommon,
-              AudienceUpdateRequest1,
+
           ],
           'oneOf': [
           ],

--- a/pinterest/generated/client/model/campaign_create_common.py
+++ b/pinterest/generated/client/model/campaign_create_common.py
@@ -369,8 +369,7 @@ class CampaignCreateCommon(ModelComposed):
           'anyOf': [
           ],
           'allOf': [
-              CampaignCommon,
-              CampaignCreateCommonAllOf,
+
           ],
           'oneOf': [
           ],

--- a/pinterest/generated/client/model/campaign_create_request.py
+++ b/pinterest/generated/client/model/campaign_create_request.py
@@ -375,8 +375,7 @@ class CampaignCreateRequest(ModelComposed):
           'anyOf': [
           ],
           'allOf': [
-              CampaignCreateCommon,
-              CampaignCreateRequestAllOf,
+
           ],
           'oneOf': [
           ],

--- a/pinterest/generated/client/model/campaign_create_response_data.py
+++ b/pinterest/generated/client/model/campaign_create_response_data.py
@@ -398,9 +398,7 @@ class CampaignCreateResponseData(ModelComposed):
           'anyOf': [
           ],
           'allOf': [
-              CampaignCreateCommon,
-              CampaignCreateResponseDataAllOf,
-              CampaignResponse,
+
           ],
           'oneOf': [
           ],

--- a/pinterest/generated/client/model/campaign_response.py
+++ b/pinterest/generated/client/model/campaign_response.py
@@ -390,9 +390,7 @@ class CampaignResponse(ModelComposed):
           'anyOf': [
           ],
           'allOf': [
-              CampaignCommon,
-              CampaignId,
-              CampaignResponseAllOf,
+
           ],
           'oneOf': [
           ],

--- a/pinterest/generated/client/model/campaign_update_request.py
+++ b/pinterest/generated/client/model/campaign_update_request.py
@@ -382,10 +382,7 @@ class CampaignUpdateRequest(ModelComposed):
           'anyOf': [
           ],
           'allOf': [
-              CampaignCommon,
-              CampaignCreateCommon,
-              CampaignId,
-              CampaignUpdateRequestAllOf,
+
           ],
           'oneOf': [
           ],

--- a/pinterest/generated/client/model/campaign_update_response.py
+++ b/pinterest/generated/client/model/campaign_update_response.py
@@ -307,7 +307,7 @@ class CampaignUpdateResponse(ModelComposed):
           'anyOf': [
           ],
           'allOf': [
-              CampaignCreateResponse,
+
           ],
           'oneOf': [
           ],

--- a/pinterest/generated/client/model/catalogs_feed.py
+++ b/pinterest/generated/client/model/catalogs_feed.py
@@ -369,8 +369,7 @@ class CatalogsFeed(ModelComposed):
           'anyOf': [
           ],
           'allOf': [
-              CatalogsDbItem,
-              FeedFields,
+
           ],
           'oneOf': [
           ],

--- a/pinterest/generated/client/model/catalogs_feed_processing_result.py
+++ b/pinterest/generated/client/model/catalogs_feed_processing_result.py
@@ -339,8 +339,7 @@ class CatalogsFeedProcessingResult(ModelComposed):
           'anyOf': [
           ],
           'allOf': [
-              CatalogsDbItem,
-              CatalogsFeedProcessingResultFields,
+
           ],
           'oneOf': [
           ],

--- a/pinterest/generated/client/model/catalogs_items_batch_request.py
+++ b/pinterest/generated/client/model/catalogs_items_batch_request.py
@@ -339,6 +339,7 @@ class CatalogsItemsBatchRequest(ModelComposed):
           'anyOf': [
           ],
           'allOf': [
+
           ],
           'oneOf': [
               CatalogsItemsCreateBatchRequest,

--- a/pinterest/generated/client/model/catalogs_list_products_by_filter_request.py
+++ b/pinterest/generated/client/model/catalogs_list_products_by_filter_request.py
@@ -316,6 +316,7 @@ class CatalogsListProductsByFilterRequest(ModelComposed):
           'anyOf': [
           ],
           'allOf': [
+
           ],
           'oneOf': [
               CatalogsListProductsByFilterRequestOneOf,

--- a/pinterest/generated/client/model/catalogs_product_group.py
+++ b/pinterest/generated/client/model/catalogs_product_group.py
@@ -358,6 +358,7 @@ class CatalogsProductGroup(ModelComposed):
           'anyOf': [
           ],
           'allOf': [
+
           ],
           'oneOf': [
               CatalogsProductGroupFeedBasedCase,

--- a/pinterest/generated/client/model/catalogs_product_group_create_request.py
+++ b/pinterest/generated/client/model/catalogs_product_group_create_request.py
@@ -328,6 +328,7 @@ class CatalogsProductGroupCreateRequest(ModelComposed):
           'anyOf': [
           ],
           'allOf': [
+
           ],
           'oneOf': [
               ProductGroupsCreateRequestFeedBaseCase,

--- a/pinterest/generated/client/model/catalogs_product_group_filter_keys.py
+++ b/pinterest/generated/client/model/catalogs_product_group_filter_keys.py
@@ -489,6 +489,7 @@ class CatalogsProductGroupFilterKeys(ModelComposed):
               ProductType4Filter,
           ],
           'allOf': [
+
           ],
           'oneOf': [
           ],

--- a/pinterest/generated/client/model/catalogs_product_group_filters.py
+++ b/pinterest/generated/client/model/catalogs_product_group_filters.py
@@ -315,6 +315,7 @@ class CatalogsProductGroupFilters(ModelComposed):
               CatalogsProductGroupFiltersAnyOf,
           ],
           'allOf': [
+
           ],
           'oneOf': [
           ],

--- a/pinterest/generated/client/model/catalogs_product_group_filters_all_of_request.py
+++ b/pinterest/generated/client/model/catalogs_product_group_filters_all_of_request.py
@@ -321,6 +321,7 @@ class CatalogsProductGroupFiltersAllOfRequest(ModelComposed):
               CatalogsProductGroupFiltersAllOfRequestAnyOf1,
           ],
           'allOf': [
+
           ],
           'oneOf': [
           ],

--- a/pinterest/generated/client/model/item_attributes.py
+++ b/pinterest/generated/client/model/item_attributes.py
@@ -494,8 +494,7 @@ class ItemAttributes(ModelComposed):
           'anyOf': [
           ],
           'allOf': [
-              ItemAttributesAllOf,
-              UpdatableItemAttributes,
+
           ],
           'oneOf': [
           ],

--- a/pinterest/generated/client/model/item_batch_record.py
+++ b/pinterest/generated/client/model/item_batch_record.py
@@ -315,6 +315,7 @@ class ItemBatchRecord(ModelComposed):
           'anyOf': [
           ],
           'allOf': [
+
           ],
           'oneOf': [
               ItemCreateBatchRecord,

--- a/pinterest/generated/client/model/item_response.py
+++ b/pinterest/generated/client/model/item_response.py
@@ -321,6 +321,7 @@ class ItemResponse(ModelComposed):
               ItemResponseAnyOf1,
           ],
           'allOf': [
+
           ],
           'oneOf': [
           ],

--- a/pinterest/generated/client/model/keyword.py
+++ b/pinterest/generated/client/model/keyword.py
@@ -345,7 +345,7 @@ class Keyword(ModelComposed):
           'anyOf': [
           ],
           'allOf': [
-              KeywordsCommon,
+
           ],
           'oneOf': [
           ],

--- a/pinterest/generated/client/model/media_upload.py
+++ b/pinterest/generated/client/model/media_upload.py
@@ -321,7 +321,7 @@ class MediaUpload(ModelComposed):
           'anyOf': [
           ],
           'allOf': [
-              MediaUploadAllOf,
+
           ],
           'oneOf': [
           ],

--- a/pinterest/generated/client/model/oauth_access_token_request_code.py
+++ b/pinterest/generated/client/model/oauth_access_token_request_code.py
@@ -329,8 +329,7 @@ class OauthAccessTokenRequestCode(ModelComposed):
           'anyOf': [
           ],
           'allOf': [
-              OauthAccessTokenRequest,
-              OauthAccessTokenRequestCodeAllOf,
+
           ],
           'oneOf': [
           ],

--- a/pinterest/generated/client/model/oauth_access_token_request_refresh.py
+++ b/pinterest/generated/client/model/oauth_access_token_request_refresh.py
@@ -329,8 +329,7 @@ class OauthAccessTokenRequestRefresh(ModelComposed):
           'anyOf': [
           ],
           'allOf': [
-              OauthAccessTokenRequest,
-              OauthAccessTokenRequestRefreshAllOf,
+
           ],
           'oneOf': [
           ],

--- a/pinterest/generated/client/model/oauth_access_token_response_code.py
+++ b/pinterest/generated/client/model/oauth_access_token_response_code.py
@@ -347,8 +347,7 @@ class OauthAccessTokenResponseCode(ModelComposed):
           'anyOf': [
           ],
           'allOf': [
-              OauthAccessTokenResponse,
-              OauthAccessTokenResponseCodeAllOf,
+
           ],
           'oneOf': [
           ],

--- a/pinterest/generated/client/model/oauth_access_token_response_refresh.py
+++ b/pinterest/generated/client/model/oauth_access_token_response_refresh.py
@@ -337,7 +337,7 @@ class OauthAccessTokenResponseRefresh(ModelComposed):
           'anyOf': [
           ],
           'allOf': [
-              OauthAccessTokenResponse,
+
           ],
           'oneOf': [
           ],

--- a/pinterest/generated/client/model/pin_media_source.py
+++ b/pinterest/generated/client/model/pin_media_source.py
@@ -358,6 +358,7 @@ class PinMediaSource(ModelComposed):
           'anyOf': [
           ],
           'allOf': [
+
           ],
           'oneOf': [
               PinMediaSourceImageBase64,

--- a/pinterest/generated/client/model/pin_media_with_image.py
+++ b/pinterest/generated/client/model/pin_media_with_image.py
@@ -323,8 +323,7 @@ class PinMediaWithImage(ModelComposed):
           'anyOf': [
           ],
           'allOf': [
-              PinMedia,
-              PinMediaWithImageAllOf,
+
           ],
           'oneOf': [
           ],

--- a/pinterest/generated/client/model/pin_media_with_video.py
+++ b/pinterest/generated/client/model/pin_media_with_video.py
@@ -339,8 +339,7 @@ class PinMediaWithVideo(ModelComposed):
           'anyOf': [
           ],
           'allOf': [
-              PinMedia,
-              PinMediaWithVideoAllOf,
+
           ],
           'oneOf': [
           ],

--- a/pinterest/generated/client/model/product_group_promotion.py
+++ b/pinterest/generated/client/model/product_group_promotion.py
@@ -398,7 +398,7 @@ class ProductGroupPromotion(ModelComposed):
           'anyOf': [
           ],
           'allOf': [
-              ProductGroupPromotionCommon,
+
           ],
           'oneOf': [
           ],


### PR DESCRIPTION
Remove `allOf` composed_class requirement from all models
- `allOf` causing issues as child model methods are not overriding parent methods as expected
- to fix this problem, the .mustache template is changed to remove the parent classes from `allOf` list